### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/fastcampus-board-project/build.gradle
+++ b/fastcampus-board-project/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'

--- a/fastcampus-board-project/src/main/java/com/fastcampus/boardproject/repository/ArticleCommentRepository.java
+++ b/fastcampus-board-project/src/main/java/com/fastcampus/boardproject/repository/ArticleCommentRepository.java
@@ -2,8 +2,10 @@ package com.fastcampus.boardproject.repository;
 
 import com.fastcampus.boardproject.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 
 }

--- a/fastcampus-board-project/src/main/java/com/fastcampus/boardproject/repository/ArticleRepository.java
+++ b/fastcampus-board-project/src/main/java/com/fastcampus/boardproject/repository/ArticleRepository.java
@@ -2,8 +2,10 @@ package com.fastcampus.boardproject.repository;
 
 import com.fastcampus.boardproject.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 }

--- a/fastcampus-board-project/src/test/java/com/fastcampus/boardproject/controller/DataRestTest.java
+++ b/fastcampus-board-project/src/test/java/com/fastcampus/boardproject/controller/DataRestTest.java
@@ -1,0 +1,103 @@
+package com.fastcampus.boardproject.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void givenNoting_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+
+        //given
+
+        //when
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+        //then
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void givenNoting_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+
+        //given
+
+        //when
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+        //then
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void givenNoting_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+
+        //given
+
+        //when
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+        //then
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void givenNoting_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+
+        //given
+
+        //when
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+        //then
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void givenNoting_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+
+        //given
+
+        //when
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+        //then
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST 로 서비스 하고, 해당 api 들의 존재 여부만 체크하게끔 통합테스트 작성