### PR TITLE
[고도화] 보안 기능 고도화 - 환경변수의 사용

### DIFF
--- a/src/main/java/com/fastcampus/boardproject/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/boardproject/config/SecurityConfig.java
@@ -1,9 +1,7 @@
 package com.fastcampus.boardproject.config;
 
-import com.fastcampus.boardproject.dto.UserAccountDto;
 import com.fastcampus.boardproject.dto.security.BoardPrincipal;
 import com.fastcampus.boardproject.dto.security.KakaoOAuth2Response;
-import com.fastcampus.boardproject.repository.UserAccountRepository;
 import com.fastcampus.boardproject.service.UserAccountService;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -47,7 +45,7 @@ public class SecurityConfig {
                 .logout(logout -> logout.logoutSuccessUrl("/"))
                 .oauth2Login(oAuth -> oAuth
                         .userInfoEndpoint(userInfo -> userInfo
-                                        .userService(oAuth2UserService)
+                                .userService(oAuth2UserService)
                         )
                 )
                 .build();
@@ -75,7 +73,6 @@ public class SecurityConfig {
             String registrationId = userRequest.getClientRegistration().getRegistrationId(); //"kakao"
             String providerId = String.valueOf(kakaoResponse.id());
             String username = registrationId + "_" + providerId;
-
             String dummyPassword = passwordEncoder.encode("{bcrypt}" + UUID.randomUUID());
 
             return userAccountService.searchUser(username)
@@ -88,7 +85,6 @@ public class SecurityConfig {
                                             kakaoResponse.email(),
                                             kakaoResponse.nickname(),
                                             null
-
                                     )
                             )
                     );

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,12 +13,9 @@ logging:
 
 spring:
   datasource:
-#    url: jdbc:mysql://localhost:3306/fastcampus_board
-#    username: hooney200
-#    password: hooney1108!
-    url: jdbc:postgresql://localhost:5432/fastcampus_board
-    username: hooney
-    password: 1234
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
 
 #    h2 Test property
 #    url: jdbc:h2:mem:testdb
@@ -65,7 +62,7 @@ spring:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kauth.kakao.com/v2/usre/me
+            user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
 ---


### PR DESCRIPTION
이 pr은 `application.yaml`에 노출되어 있던 각종 민감정보를 변수로 치환하여 보안을 신경쓰도록 한다.
그러나.. 사실 이미 늦었다. 이전 과거 기록(커밋 노드)을 조회하면 여전히 노출된 값을 볼 수 있기 때문.
근본적인 해결을 하려면 이 저장소를 통쨰로 지우고 새로 올리는 수 밖에 없을 것 같다.
일단 공부를 하는 의미는 있으므로 이 pr을 적용한다.

This closes #76 